### PR TITLE
feat: add ESC key shortcut to close window

### DIFF
--- a/js/plugin.js
+++ b/js/plugin.js
@@ -9,6 +9,12 @@ eagle.onPluginCreate(async (plugin) => {
 		window.close()
 	})
 
+	document.addEventListener("keydown", (e) => {
+		if (e.key === "Escape") {
+			window.close()
+		}
+	})
+
 	document.getElementById('downloadForm').addEventListener('submit', async (e) => {
 		e.preventDefault();
 		await downloadAndImport();


### PR DESCRIPTION
## Changes

- Add keyboard event listener for the `Escape` key to close the plugin window
- Provides a convenient shortcut alongside the existing close button