### PR TITLE
feat: add GIF download support with MP4-to-GIF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 # Eagle Twitter / X Video Downloader
 
-This Eagle plugin lets you download high-quality videos from Twitter / X and automatically add their URL and title.
+This Eagle plugin lets you download high-quality videos and GIFs from Twitter / X and automatically add their URL and title.
 
-> [!WARNING]  
-> This plugin relies on [Twitsave](https://twitsave.com/) to download videos. 
-> See issue [Remove third-party dependency on Twitsave](https://github.com/OlivierEstevez/eagle-twitter-video-downloader/issues/1).
+## Features
+
+- Download videos from Twitter / X tweets
+- Download GIFs from Twitter / X tweets (auto-converted from MP4 to GIF via ffmpeg)
+- Supports both `twitter.com` and `x.com` URLs
+- Auto-imports to Eagle with tweet text as name and `twitter` tag
+
+## Prerequisites
+
+- **ffmpeg** (required for GIF downloads) — Install via [Homebrew](https://brew.sh/) (`brew install ffmpeg`), or download from [ffmpeg.org](https://ffmpeg.org/download.html). The plugin searches common locations including `~/.local/bin`, `/usr/local/bin`, and `/opt/homebrew/bin`.
 
 ## Installation
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 			<div class="container">
 				<label for="twitterUrl">Twitter / X URL</label>
 				<form id="downloadForm">
-					<input type="text" id="twitterUrl" placeholder="Paste Twitter video URL here">
+					<input type="text" id="twitterUrl" placeholder="Paste Twitter video or GIF URL here">
 					<button type="submit"><span>Download</span></button>
 				</form>
 				<div id="status"></div>

--- a/js/plugin.js
+++ b/js/plugin.js
@@ -54,13 +54,150 @@ const returnError = (message) => {
 	})
 }
 
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+const https = require('https');
+const http = require('http');
+
+function downloadFile(url, destPath) {
+	return new Promise((resolve, reject) => {
+		const client = url.startsWith('https') ? https : http;
+		client.get(url, (response) => {
+			if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+				return downloadFile(response.headers.location, destPath).then(resolve).catch(reject);
+			}
+			const fileStream = fs.createWriteStream(destPath);
+			response.pipe(fileStream);
+			fileStream.on('finish', () => { fileStream.close(); resolve(); });
+			fileStream.on('error', reject);
+		}).on('error', reject);
+	});
+}
+
+function buildFullPath() {
+	const home = os.homedir();
+	const extraPaths = [
+		path.join(home, '.local', 'bin'),
+		path.join(home, 'bin'),
+		'/usr/local/bin',
+		'/opt/homebrew/bin',
+	];
+	let basePath = process.env.PATH || '';
+	try {
+		const shell = process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash';
+		basePath = execSync(`${shell} -l -c 'echo $PATH'`, { encoding: 'utf-8' }).trim();
+	} catch (_) {}
+	const allPaths = [...new Set([...extraPaths, ...basePath.split(':')])];
+	return allPaths.join(':');
+}
+
+const FULL_PATH = buildFullPath();
+
+function findFfmpeg() {
+	try {
+		return execSync('which ffmpeg', { encoding: 'utf-8', env: { ...process.env, PATH: FULL_PATH } }).trim();
+	} catch (_) {}
+	return null;
+}
+
+async function convertMp4ToGif(mp4Url) {
+	const ffmpeg = findFfmpeg();
+	console.log('FULL_PATH:', FULL_PATH);
+	console.log('ffmpeg path:', ffmpeg);
+	if (!ffmpeg) {
+		console.error('ffmpeg not found');
+		return null;
+	}
+
+	const tmpDir = os.tmpdir();
+	const ts = Date.now();
+	const mp4Path = path.join(tmpDir, `twitter_gif_${ts}.mp4`);
+	const gifPath = path.join(tmpDir, `twitter_gif_${ts}.gif`);
+
+	try {
+		await downloadFile(mp4Url, mp4Path);
+		console.log('mp4 downloaded, size:', fs.statSync(mp4Path).size);
+		execSync(`"${ffmpeg}" -i "${mp4Path}" -vf "fps=15,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" -loop 0 -y "${gifPath}"`, { env: { ...process.env, PATH: FULL_PATH } });
+		console.log('gif converted, size:', fs.statSync(gifPath).size);
+		return gifPath;
+	} catch (e) {
+		console.error('ffmpeg conversion failed:', e.message);
+		try { fs.unlinkSync(gifPath); } catch (_) {}
+		return null;
+	} finally {
+		try { fs.unlinkSync(mp4Path); } catch (_) {}
+	}
+}
+
+function extractTweetId(url) {
+	const match = url.match(/\/status\/(\d+)/);
+	return match ? match[1] : null;
+}
+
+async function downloadViaSyndication(url, tweetId) {
+	const apiUrl = `https://cdn.syndication.twimg.com/tweet-result?id=${tweetId}&token=0`;
+	const response = await fetch(apiUrl);
+	if (!response.ok) return null;
+
+	const data = await response.json();
+	const tweetText = data.text?.replace(/https?:\/\/\S+/g, '').trim() || 'Twitter Media';
+	const mediaItems = [];
+
+	// Collect GIFs and videos from mediaDetails
+	if (data.mediaDetails) {
+		for (const media of data.mediaDetails) {
+			if (media.type === 'animated_gif' || media.type === 'video') {
+				const variants = media.video_info?.variants?.filter(v => v.content_type === 'video/mp4') || [];
+				// Pick the highest bitrate variant
+				const best = variants.sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0))[0];
+				if (best) {
+					mediaItems.push({
+						url: best.url,
+						type: media.type === 'animated_gif' ? 'gif' : 'video',
+					});
+				}
+			}
+		}
+	}
+
+	if (mediaItems.length === 0) return null;
+	return { tweetText, mediaItems };
+}
+
+async function downloadViaTwitsave(url) {
+	const apiUrl = `https://twitsave.com/info?url=${url}`;
+	const response = await fetch(apiUrl);
+	const text = await response.text();
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(text, 'text/html');
+
+	const videoContainers = doc.querySelectorAll('.origin-top-right');
+	const tweetText = doc.querySelector('.leading-tight p.m-2')?.textContent || 'Twitter Video';
+
+	if (videoContainers.length === 0) return null;
+
+	const mediaItems = [];
+	for (const container of videoContainers) {
+		const qualityButtons = container.querySelectorAll('a');
+		const videoUrl = qualityButtons[0]?.href;
+		if (videoUrl) {
+			mediaItems.push({ url: videoUrl, type: 'video' });
+		}
+	}
+
+	if (mediaItems.length === 0) return null;
+	return { tweetText, mediaItems };
+}
+
 async function downloadAndImport() {
 	const statusEl = document.getElementById('status');
 	const urlInput = document.getElementById('twitterUrl');
 	const url = urlInput.value.trim();
 
 	// Check if URL is specifically from Twitter/X
-	const twitterRegex = /^https?:\/\/(www\.)?(twitter|x)\.com\/\w+\/status\/\d+/i;
+	const twitterRegex = /^https?:\/\/(www\.)?(twitter|x)\.com\/(\w+|i)\/status\/\d+/i;
 	if (!url) {
 		statusEl.textContent = 'Please enter a Twitter/X video URL';
 		return;
@@ -72,48 +209,64 @@ async function downloadAndImport() {
 	}
 
 	try {
-			statusEl.textContent = 'Fetching video information...';
+			statusEl.textContent = 'Fetching media information...';
 
-			// Call the API to get video information
-			const apiUrl = `https://twitsave.com/info?url=${url}`;
-			const response = await fetch(apiUrl);
-			const text = await response.text();
-			const parser = new DOMParser();
-			const doc = parser.parseFromString(text, 'text/html');
+			const tweetId = extractTweetId(url);
+			let result = null;
 
-			// Find all video containers
-			const videoContainers = doc.querySelectorAll('.origin-top-right');
-			const tweetText = doc.querySelector('.leading-tight p.m-2')?.textContent || 'Twitter Video';
-
-			if (videoContainers.length === 0) {
-					returnError('No videos found in the tweet.');
-					return;
+			// Try syndication API first (supports both videos and GIFs)
+			if (tweetId) {
+				result = await downloadViaSyndication(url, tweetId);
 			}
 
-			statusEl.textContent = `Found ${videoContainers.length} video(s). Downloading...`;
+			// Fallback to twitsave for videos
+			if (!result) {
+				result = await downloadViaTwitsave(url);
+			}
 
-			// Process each video
-			for (let i = 0; i < videoContainers.length; i++) {
-					const container = videoContainers[i];
-					const qualityButtons = container.querySelectorAll('a');
-					const videoUrl = qualityButtons[0]?.href;
+			if (!result || result.mediaItems.length === 0) {
+				returnError('No videos or GIFs found in the tweet.');
+				return;
+			}
 
-					if (!videoUrl) {
-							statusEl.textContent = `Could not find download URL for video ${i + 1}`;
-							continue;
-					}
+			const { tweetText, mediaItems } = result;
+			statusEl.textContent = `Found ${mediaItems.length} media item(s). Downloading...`;
 
-					// Add to Eagle using the API
-					const itemId = await eagle.item.addFromURL(videoUrl, {
-							name: videoContainers.length === 1 ? tweetText : `${tweetText}_video${i + 1}`,
+			for (let i = 0; i < mediaItems.length; i++) {
+					const media = mediaItems[i];
+					const suffix = mediaItems.length > 1 ? `_${media.type}${i + 1}` : '';
+					const itemName = `${tweetText}${suffix}`;
+
+					if (media.type === 'gif') {
+						statusEl.textContent = `Converting GIF ${i + 1} of ${mediaItems.length}...`;
+						const gifPath = await convertMp4ToGif(media.url);
+						if (gifPath) {
+							await eagle.item.addFromPath(gifPath, {
+								name: itemName,
+								website: url,
+								tags: ['twitter']
+							});
+							try { fs.unlinkSync(gifPath); } catch (_) {}
+						} else {
+							// Fallback to MP4 if ffmpeg is not available
+							await eagle.item.addFromURL(media.url, {
+								name: itemName,
+								website: url,
+								tags: ['twitter']
+							});
+						}
+					} else {
+						await eagle.item.addFromURL(media.url, {
+							name: itemName,
 							website: url,
 							tags: ['twitter']
-					});
+						});
+					}
 
-					statusEl.textContent = `Imported video ${i + 1} of ${videoContainers.length}`;
+					statusEl.textContent = `Imported ${i + 1} of ${mediaItems.length}`;
 			}
 
-			statusEl.textContent = 'All videos imported successfully!';
+			statusEl.textContent = 'All media imported successfully!';
 			urlInput.value = '';
 
 	} catch (error) {


### PR DESCRIPTION
## Changes

- Use Twitter Syndication API as primary source (supports both videos and GIFs)
- Keep Twitsave as fallback for video downloads
- Convert Twitter's MP4-encoded GIFs to actual GIF format via ffmpeg
- Auto-detect ffmpeg from common install locations (`~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`)
- Support `x.com/i/status/` URL format
- Update README with features, prerequisites and ffmpeg requirement

## Prerequisites

This feature requires `ffmpeg` installed on the system for MP4-to-GIF conversion.