### PR TITLE
feat: add auto-close option after successful download

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -174,14 +174,66 @@ button:hover {
   background-image: linear-gradient(0deg, var(--background-mix-color), var(--background-mix-color)) !important;
 }
 
+/* Status Row */
+#statusRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.6em;
+}
+
 /* Status Message */
 #status {
-  position: absolute;
   font-size: 13px;
   color: var(--color-text-tertiary);
-  margin-top: 0.6em;
 }
 
 #status.error {
   color: #f56c6c;
+}
+
+/* Setting Toggle */
+.setting-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.setting-toggle input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  cursor: pointer;
+  border: 1.5px solid var(--color-text-tertiary);
+  border-radius: 3px;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.setting-toggle input[type="checkbox"]:checked {
+  background: rgb(50, 151, 255);
+  border-color: rgb(50, 151, 255);
+}
+
+.setting-toggle input[type="checkbox"]:checked::after {
+  content: '';
+  display: block;
+  width: 3.5px;
+  height: 7px;
+  border: solid #fff;
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(45deg) translateY(-0.5px);
+}
+
+.setting-label {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -202,34 +202,32 @@ button:hover {
   flex-shrink: 0;
 }
 
-.setting-toggle input[type="checkbox"] {
-  appearance: none;
-  -webkit-appearance: none;
+.checkbox-custom {
   width: 14px;
   height: 14px;
-  margin: 0;
-  cursor: pointer;
   border: 1.5px solid var(--color-text-tertiary);
   border-radius: 3px;
   background: transparent;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
 }
 
-.setting-toggle input[type="checkbox"]:checked {
+.setting-toggle input[type="checkbox"]:checked + .checkbox-custom {
   background: rgb(50, 151, 255);
   border-color: rgb(50, 151, 255);
 }
 
-.setting-toggle input[type="checkbox"]:checked::after {
+.setting-toggle input[type="checkbox"]:checked + .checkbox-custom::after {
   content: '';
-  display: block;
+  position: absolute;
+  left: 3px;
+  top: 0px;
   width: 3.5px;
   height: 7px;
   border: solid #fff;
   border-width: 0 1.5px 1.5px 0;
-  transform: rotate(45deg) translateY(-0.5px);
+  transform: rotate(45deg);
 }
 
 .setting-label {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,13 @@
 					<input type="text" id="twitterUrl" placeholder="Paste Twitter video URL here">
 					<button type="submit"><span>Download</span></button>
 				</form>
-				<div id="status"></div>
+				<div id="statusRow">
+					<div id="status"></div>
+					<label class="setting-toggle">
+						<input type="checkbox" id="autoClose">
+						<span class="setting-label">Auto close</span>
+					</label>
+				</div>
 			</div>
 		</main>
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
 				<div id="statusRow">
 					<div id="status"></div>
 					<label class="setting-toggle">
-						<input type="checkbox" id="autoClose">
+						<input type="checkbox" id="autoClose" hidden>
+						<span class="checkbox-custom"></span>
 						<span class="setting-label">Auto close</span>
 					</label>
 				</div>

--- a/js/plugin.js
+++ b/js/plugin.js
@@ -5,6 +5,13 @@ eagle.onPluginCreate(async (plugin) => {
 
 	document.getElementById("twitterUrl").focus()
 
+	// Load auto-close setting
+	const autoCloseCheckbox = document.getElementById("autoClose");
+	autoCloseCheckbox.checked = localStorage.getItem("autoClose") === "true";
+	autoCloseCheckbox.addEventListener("change", () => {
+		localStorage.setItem("autoClose", autoCloseCheckbox.checked);
+	});
+
 	document.getElementById("closeButton").addEventListener("click", () => {
 		window.close()
 	})
@@ -122,6 +129,10 @@ async function downloadAndImport() {
 
 			statusEl.textContent = 'All videos imported successfully!';
 			urlInput.value = '';
+
+			if (localStorage.getItem("autoClose") === "true") {
+				setTimeout(() => window.close(), 1000);
+			}
 
 	} catch (error) {
 			statusEl.textContent = `Error: ${error.message}`;


### PR DESCRIPTION
## Changes

<img width="592" height="292" alt="image" src="https://github.com/user-attachments/assets/a1580416-b935-4c4f-aa03-2da8f97b14a6" />

- Add an `Auto close` checkbox to the UI
- Persist the setting in `localStorage`
- Automatically close the plugin window 1 second after successful import when enabled

This is a small UX improvement for users who want the plugin to get out of the way after downloading.